### PR TITLE
feat: add create event screen with form, pickers, and validation (NEB-79)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@powersync/react": "^1.8.2",
         "@powersync/react-native": "^1.29.0",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/datetimepicker": "^8.6.0",
         "@react-navigation/bottom-tabs": "^7.12.0",
         "@react-navigation/drawer": "^7.8.1",
         "@react-navigation/native": "^7.1.28",
@@ -5434,6 +5435,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.6.0.tgz",
+      "integrity": "sha512-yxPSqNfxgpGaqHQIpatqe6ykeBdU/1pdsk/G3x01mY2bpTflLpmVTLqFSJYd3MiZzxNZcMs/j1dQakUczSjcYA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@powersync/react": "^1.8.2",
     "@powersync/react-native": "^1.29.0",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "^8.6.0",
     "@react-navigation/bottom-tabs": "^7.12.0",
     "@react-navigation/drawer": "^7.8.1",
     "@react-navigation/native": "^7.1.28",

--- a/src/database/schemas/__tests__/eventSchemas.test.ts
+++ b/src/database/schemas/__tests__/eventSchemas.test.ts
@@ -1,0 +1,45 @@
+import { CreateEventSchema } from '../eventSchemas';
+
+const validData = {
+  title: 'Team Standup',
+  calendarId: 'cal-123',
+  startTime: new Date('2026-03-02T13:00:00Z'),
+  endTime: new Date('2026-03-02T14:00:00Z'),
+};
+
+describe('CreateEventSchema', () => {
+  it('accepts valid event data', () => {
+    const result = CreateEventSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts optional description', () => {
+    const result = CreateEventSchema.safeParse({ ...validData, description: 'Weekly sync' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty title', () => {
+    const result = CreateEventSchema.safeParse({ ...validData, title: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty calendarId', () => {
+    const result = CreateEventSchema.safeParse({ ...validData, calendarId: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects end time equal to start time', () => {
+    const same = new Date('2026-03-02T13:00:00Z');
+    const result = CreateEventSchema.safeParse({ ...validData, startTime: same, endTime: same });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects end time before start time', () => {
+    const result = CreateEventSchema.safeParse({
+      ...validData,
+      startTime: new Date('2026-03-02T14:00:00Z'),
+      endTime: new Date('2026-03-02T13:00:00Z'),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/database/schemas/eventSchemas.ts
+++ b/src/database/schemas/eventSchemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for the Create Event form.
+ */
+export const CreateEventSchema = z
+  .object({
+    title: z.string().min(1, 'Title is required'),
+    calendarId: z.string().min(1, 'Select a calendar'),
+    startTime: z.date(),
+    endTime: z.date(),
+    description: z.string().optional(),
+  })
+  .refine((data) => data.endTime > data.startTime, {
+    message: 'End time must be after start time',
+    path: ['endTime'],
+  });
+
+export type CreateEventFormData = z.infer<typeof CreateEventSchema>;

--- a/src/database/schemas/index.ts
+++ b/src/database/schemas/index.ts
@@ -13,3 +13,4 @@ export {
   AuthResponseSchema,
   type AuthResponseData,
 } from './authSchemas';
+export { CreateEventSchema, type CreateEventFormData } from './eventSchemas';

--- a/src/hooks/useScheduleFeed.ts
+++ b/src/hooks/useScheduleFeed.ts
@@ -58,7 +58,10 @@ export function buildSections(
   const eventsByDate = new Map<string, FeedEvent[]>();
   for (const event of events) {
     if (!event.start_time) continue;
-    const dateKey = event.start_time.slice(0, 10);
+    // Convert UTC to local date for correct day bucketing
+    const localDate = new Date(event.start_time);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const dateKey = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}`;
     const existing = eventsByDate.get(dateKey);
     if (existing) {
       existing.push(event);

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -84,11 +84,7 @@ function MainNavigator() {
     <Stack.Navigator>
       <Stack.Screen name="Main" component={MainDrawer} options={{ headerShown: false }} />
       <Stack.Screen name="Profile" component={ProfileScreen} />
-      <Stack.Screen
-        name="CreateEvent"
-        component={CreateEventScreen}
-        options={{ headerShown: false }}
-      />
+      <Stack.Screen name="CreateEvent" component={CreateEventScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/CreateEventScreen.tsx
+++ b/src/screens/CreateEventScreen.tsx
@@ -1,26 +1,378 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable as RNPressable,
+  ScrollView,
+  StyleSheet,
+  Text as RNText,
+  TextInput,
+  View,
+} from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { tva } from '@gluestack-ui/utils/nativewind-utils';
-import { Box } from '@/components/ui/box';
 import { Text } from '@/components/ui/text';
+import { HStack } from '@/components/ui/hstack';
 import { VStack } from '@/components/ui/vstack';
-import { Button, ButtonText } from '@/components/ui/button';
+import { Pressable } from '@/components/ui/pressable';
+import { useCalendars } from '@hooks/useCalendars';
+import { useCurrentUser } from '@hooks/useCurrentUser';
+import { useEventMutations } from '@hooks/useCalendarEvents';
+import { CreateEventSchema } from '@database/schemas';
+import { formatDateShort, formatTime } from '@utils/formatTime';
+import { ZodError } from 'zod';
 
-const containerStyle = tva({ base: 'flex-1 items-center justify-center bg-background-0 px-6' });
-const titleStyle = tva({ base: 'text-xl font-bold text-typography-900' });
-const bodyStyle = tva({ base: 'mt-2 text-center text-base text-typography-500' });
+// --- Styles ---
+
+const containerStyle = tva({ base: 'flex-1 bg-background-0' });
+const sectionLabelStyle = tva({ base: 'text-sm text-typography-500' });
+const dateTimeTextStyle = tva({ base: 'text-base text-typography-900' });
+const dateTimeSeparatorStyle = tva({ base: 'text-base text-typography-400' });
+const errorTextStyle = tva({ base: 'mt-1 text-sm text-error-600' });
+const calendarNameStyle = tva({ base: 'flex-1 text-base text-typography-900' });
+const chevronStyle = tva({ base: 'text-base text-typography-400' });
+const addDetailsStyle = tva({ base: 'text-base text-primary-500' });
+const descriptionLabelStyle = tva({ base: 'text-sm text-typography-500' });
+const dividerStyle = tva({ base: 'h-px bg-outline-200' });
+
+const styles = StyleSheet.create({
+  scrollContent: { flexGrow: 1 },
+  calendarDot: { width: 10, height: 10, borderRadius: 5 },
+  titleInput: {
+    fontSize: 16,
+    color: '#262627',
+    paddingVertical: 8,
+    paddingHorizontal: 0,
+  },
+  descriptionInput: {
+    fontSize: 16,
+    color: '#262627',
+    minHeight: 100,
+    textAlignVertical: 'top',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    borderColor: '#E5E5E5',
+    borderRadius: 8,
+  },
+});
+
+// --- Helpers ---
+
+function getNextWholeHour(): Date {
+  const d = new Date();
+  d.setMinutes(0, 0, 0);
+  d.setHours(d.getHours() + 1);
+  return d;
+}
+
+function addHours(date: Date, hours: number): Date {
+  return new Date(date.getTime() + hours * 60 * 60 * 1000);
+}
+
+type PickerTarget = 'startDate' | 'startTime' | 'endDate' | 'endTime' | null;
+
+// --- Component ---
 
 export function CreateEventScreen() {
   const navigation = useNavigation();
+  const { data: calendars } = useCalendars();
+  const { authUser } = useCurrentUser();
+  const { createEvent } = useEventMutations();
+
+  const defaultStart = useMemo(() => getNextWholeHour(), []);
+  const defaultEnd = useMemo(() => addHours(defaultStart, 1), [defaultStart]);
+
+  // Form state
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [startTime, setStartTime] = useState(defaultStart);
+  const [endTime, setEndTime] = useState(defaultEnd);
+  const [showDescription, setShowDescription] = useState(false);
+  const [pickerTarget, setPickerTarget] = useState<PickerTarget>(null);
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+  const [isSaving, setIsSaving] = useState(false);
+
+  const titleInputRef = useRef<TextInput>(null);
+
+  const calendar = calendars?.[0];
+
+  // Derived state
+  const isDirty =
+    title.trim() !== '' ||
+    description.trim() !== '' ||
+    startTime.getTime() !== defaultStart.getTime() ||
+    endTime.getTime() !== defaultEnd.getTime();
+
+  const isValid = title.trim().length > 0 && endTime > startTime;
+
+  // --- Handlers ---
+
+  const handleClose = useCallback(() => {
+    if (isDirty) {
+      Alert.alert('Discard Changes?', 'You have unsaved changes that will be lost.', [
+        { text: 'Keep Editing', style: 'cancel' },
+        { text: 'Discard', style: 'destructive', onPress: () => navigation.goBack() },
+      ]);
+    } else {
+      navigation.goBack();
+    }
+  }, [isDirty, navigation]);
+
+  const handleSave = useCallback(async () => {
+    if (!calendar || !authUser || isSaving) return;
+
+    try {
+      CreateEventSchema.parse({
+        title,
+        calendarId: calendar.id,
+        startTime,
+        endTime,
+        description: description || undefined,
+      });
+      setFormErrors({});
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const errors: Record<string, string> = {};
+        err.issues.forEach((issue) => {
+          const field = String(issue.path[0]);
+          if (!errors[field]) {
+            errors[field] = issue.message;
+          }
+        });
+        setFormErrors(errors);
+      }
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await createEvent({
+        calendarId: calendar.id,
+        createdByUserId: authUser.id,
+        title: title.trim(),
+        description: description.trim() || undefined,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+      });
+      navigation.goBack();
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    calendar,
+    authUser,
+    isSaving,
+    title,
+    description,
+    startTime,
+    endTime,
+    createEvent,
+    navigation,
+  ]);
+
+  const handleStartChange = useCallback(
+    (_event: DateTimePickerEvent, date?: Date) => {
+      if (Platform.OS === 'android') setPickerTarget(null);
+      if (!date) return;
+
+      if (pickerTarget === 'startDate') {
+        const next = new Date(startTime);
+        next.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
+        setStartTime(next);
+        if (endTime <= next) setEndTime(addHours(next, 1));
+      } else {
+        const next = new Date(startTime);
+        next.setHours(date.getHours(), date.getMinutes(), 0, 0);
+        setStartTime(next);
+        if (endTime <= next) setEndTime(addHours(next, 1));
+      }
+
+      setFormErrors((prev) => {
+        if (!prev.endTime) return prev;
+        const next = { ...prev };
+        delete next.endTime;
+        return next;
+      });
+    },
+    [pickerTarget, startTime, endTime]
+  );
+
+  const handleEndChange = useCallback(
+    (_event: DateTimePickerEvent, date?: Date) => {
+      if (Platform.OS === 'android') setPickerTarget(null);
+      if (!date) return;
+
+      if (pickerTarget === 'endDate') {
+        const next = new Date(endTime);
+        next.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
+        setEndTime(next);
+      } else {
+        const next = new Date(endTime);
+        next.setHours(date.getHours(), date.getMinutes(), 0, 0);
+        setEndTime(next);
+      }
+
+      setFormErrors((prev) => {
+        if (!prev.endTime) return prev;
+        const next = { ...prev };
+        delete next.endTime;
+        return next;
+      });
+    },
+    [pickerTarget, endTime]
+  );
+
+  const endTimeError =
+    formErrors.endTime || (endTime <= startTime ? 'End time must be after start time' : undefined);
+  const showEndError = !!formErrors.endTime;
+
+  // Configure native header with Close and Save buttons
+  useEffect(() => {
+    navigation.setOptions({
+      title: 'New Event',
+      headerLeft: () => (
+        <RNPressable onPress={handleClose} hitSlop={8}>
+          <RNText style={{ fontSize: 16, color: '#666666' }}>&#x2715;</RNText>
+        </RNPressable>
+      ),
+      headerRight: () => (
+        <RNPressable onPress={handleSave} disabled={!isValid || isSaving} hitSlop={8}>
+          <RNText
+            style={{
+              fontSize: 16,
+              fontWeight: '600',
+              color: isValid ? '#00DB74' : '#D4D4D4',
+            }}
+          >
+            Save
+          </RNText>
+        </RNPressable>
+      ),
+    });
+  }, [navigation, handleClose, handleSave, isValid, isSaving]);
+
+  // --- Render ---
 
   return (
-    <Box className={containerStyle({})}>
-      <VStack className="items-center">
-        <Text className={titleStyle({})}>Create Event</Text>
-        <Text className={bodyStyle({})}>Coming soon</Text>
-        <Button className="mt-6" onPress={() => navigation.goBack()}>
-          <ButtonText>Close</ButtonText>
-        </Button>
-      </VStack>
-    </Box>
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className={containerStyle({})}
+    >
+      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        <VStack className="px-4 pt-4">
+          {/* Title */}
+          <TextInput
+            ref={titleInputRef}
+            style={styles.titleInput}
+            placeholder="Event title"
+            placeholderTextColor="#A3A3A3"
+            value={title}
+            onChangeText={setTitle}
+            autoFocus
+            returnKeyType="done"
+          />
+          <View className={dividerStyle({})} />
+
+          {/* Calendar row */}
+          <Pressable className="py-4" onPress={() => {}}>
+            <HStack className="items-center">
+              <View style={[styles.calendarDot, { backgroundColor: '#00DB74', marginRight: 10 }]} />
+              <Text className={calendarNameStyle({})}>{calendar?.name ?? 'Personal Calendar'}</Text>
+              <Text className={chevronStyle({})}>&#x203A;</Text>
+            </HStack>
+          </Pressable>
+          <View className={dividerStyle({})} />
+
+          {/* Start date/time */}
+          <VStack className="py-4">
+            <Text className={sectionLabelStyle({})}>Starts</Text>
+            <HStack className="mt-1 items-center">
+              <Pressable onPress={() => setPickerTarget('startDate')}>
+                <Text className={dateTimeTextStyle({})}>{formatDateShort(startTime)}</Text>
+              </Pressable>
+              <Text className={dateTimeSeparatorStyle({})}> &middot; </Text>
+              <Pressable onPress={() => setPickerTarget('startTime')}>
+                <Text className={dateTimeTextStyle({})}>{formatTime(startTime)}</Text>
+              </Pressable>
+            </HStack>
+          </VStack>
+
+          {(pickerTarget === 'startDate' || pickerTarget === 'startTime') && (
+            <DateTimePicker
+              value={startTime}
+              mode={pickerTarget === 'startDate' ? 'date' : 'time'}
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              onChange={handleStartChange}
+              minuteInterval={5}
+            />
+          )}
+
+          <View className={dividerStyle({})} />
+
+          {/* End date/time */}
+          <VStack className="py-4">
+            <Text className={sectionLabelStyle({})}>Ends</Text>
+            <HStack className="mt-1 items-center">
+              <Pressable onPress={() => setPickerTarget('endDate')}>
+                <Text
+                  className={dateTimeTextStyle({})}
+                  style={showEndError ? { color: '#DC2626' } : undefined}
+                >
+                  {formatDateShort(endTime)}
+                </Text>
+              </Pressable>
+              <Text className={dateTimeSeparatorStyle({})}> &middot; </Text>
+              <Pressable onPress={() => setPickerTarget('endTime')}>
+                <Text
+                  className={dateTimeTextStyle({})}
+                  style={showEndError ? { color: '#DC2626' } : undefined}
+                >
+                  {formatTime(endTime)}
+                </Text>
+              </Pressable>
+            </HStack>
+            {showEndError && endTimeError && (
+              <Text className={errorTextStyle({})}>{endTimeError}</Text>
+            )}
+          </VStack>
+
+          {(pickerTarget === 'endDate' || pickerTarget === 'endTime') && (
+            <DateTimePicker
+              value={endTime}
+              mode={pickerTarget === 'endDate' ? 'date' : 'time'}
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              onChange={handleEndChange}
+              minuteInterval={5}
+            />
+          )}
+
+          <View className={dividerStyle({})} />
+
+          {/* Description */}
+          {!showDescription ? (
+            <Pressable className="py-4" onPress={() => setShowDescription(true)}>
+              <Text className={addDetailsStyle({})}>+ Add details</Text>
+            </Pressable>
+          ) : (
+            <VStack className="py-4">
+              <Text className={descriptionLabelStyle({})}>Description</Text>
+              <TextInput
+                style={styles.descriptionInput}
+                placeholder="Add a description"
+                placeholderTextColor="#A3A3A3"
+                value={description}
+                onChangeText={setDescription}
+                multiline
+                numberOfLines={4}
+                autoFocus
+              />
+            </VStack>
+          )}
+        </VStack>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -14,8 +14,33 @@ export function formatTimeRange(startTime: string, endTime: string): string {
   return `${timeFormatter.format(start)} – ${timeFormatter.format(end)}`;
 }
 
+/**
+ * Formats a single timestamp into a short time string.
+ * e.g. "2:00 PM"
+ */
+export function formatTimeShort(isoString: string): string {
+  return timeFormatter.format(new Date(isoString));
+}
+
+const shortWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/**
+ * Formats a Date object into a short date string.
+ * e.g. "Fri, Feb 28"
+ */
+export function formatDateShort(date: Date): string {
+  return `${shortWeekdays[date.getDay()]}, ${months[date.getMonth()]} ${date.getDate()}`;
+}
+
+/**
+ * Formats a Date object into a short time string.
+ * e.g. "3:00 PM"
+ */
+export function formatTime(date: Date): string {
+  return timeFormatter.format(date);
+}
 
 /**
  * Formats a YYYY-MM-DD date string into a section header label.

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,8 +1,17 @@
-const timeFormatter = new Intl.DateTimeFormat('en-US', {
-  hour: 'numeric',
-  minute: '2-digit',
-  hour12: true,
-});
+/**
+ * Formats a Date object into a local 12-hour time string.
+ * Uses Date.getHours()/getMinutes() which always return local time,
+ * avoiding Hermes Intl.DateTimeFormat timezone issues.
+ * e.g. "3:00 PM"
+ */
+function formatLocalTime(date: Date): string {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const period = hours >= 12 ? 'PM' : 'AM';
+  const displayHours = hours % 12 || 12;
+  const displayMinutes = String(minutes).padStart(2, '0');
+  return `${displayHours}:${displayMinutes} ${period}`;
+}
 
 /**
  * Formats a start/end time pair into a human-readable range.
@@ -11,15 +20,15 @@ const timeFormatter = new Intl.DateTimeFormat('en-US', {
 export function formatTimeRange(startTime: string, endTime: string): string {
   const start = new Date(startTime);
   const end = new Date(endTime);
-  return `${timeFormatter.format(start)} – ${timeFormatter.format(end)}`;
+  return `${formatLocalTime(start)} – ${formatLocalTime(end)}`;
 }
 
 /**
- * Formats a single timestamp into a short time string.
+ * Formats a single ISO timestamp into a short time string.
  * e.g. "2:00 PM"
  */
 export function formatTimeShort(isoString: string): string {
-  return timeFormatter.format(new Date(isoString));
+  return formatLocalTime(new Date(isoString));
 }
 
 const shortWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -39,7 +48,7 @@ export function formatDateShort(date: Date): string {
  * e.g. "3:00 PM"
  */
 export function formatTime(date: Date): string {
-  return timeFormatter.format(date);
+  return formatLocalTime(date);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Implements the full Create Event screen with title input, calendar row (auto-selects first calendar), start/end date-time pickers via `@react-native-community/datetimepicker`, optional description field, and Zod validation
- Adds native stack header with Close (X) and Save buttons, discard confirmation for dirty forms, and auto-adjust of end time when start moves past it
- Stores event times in UTC via `Date.toISOString()` and saves to PowerSync via existing `useEventMutations().createEvent()`

## Known Issue

Event times display incorrectly after PowerSync sync round-trip due to the backend stripping the `Z` suffix from UTC timestamps. Tracked in [NEB-104](https://linear.app/nebbler/issue/NEB-104/timestamps-lose-utc-timezone-suffix-during-powersync-sync-round-trip).

## Test plan

- [ ] Open app, tap `+` button — CreateEvent screen opens as a regular page with native header
- [ ] Title field is auto-focused with keyboard
- [ ] Type a title — Save button turns green
- [ ] Tap start date/time — native picker opens
- [ ] Move start past end — end auto-adjusts to start + 1hr
- [ ] Set end before start manually — inline error appears, Save disabled
- [ ] Tap "Add details" — description field expands
- [ ] Tap Save — event appears in schedule feed
- [ ] Tap X with changes — discard confirmation alert
- [ ] Tap X without changes — dismisses immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)