### PR TITLE
feat: support dynamic ports for worktree development

### DIFF
--- a/.claude/rules/powersync/troubleshooting.md
+++ b/.claude/rules/powersync/troubleshooting.md
@@ -6,6 +6,8 @@ Docs: [PowerSync Debugging](https://docs.powersync.com/usage/tools/debugging)
 
 ## Quick Diagnostic Checklist
 
+> **Worktree note:** Default ports below assume the main stack. In a worktree, ports are offset (e.g. slot 1: API=4100, PowerSync=8180). Check the worktree's `api/.env` for actual port values.
+
 1. Are Docker services running? `docker compose ps` (need: postgres, powersync, api)
 2. Is the API healthy? `curl http://localhost:4000/api/health`
 3. Is PowerSync alive? `curl http://localhost:8080/probes/liveness`
@@ -108,12 +110,14 @@ PowerSync matches the JWT `kid` against JWKS entries — without it, key lookup 
 
 ## Docker Services
 
-| Service     | Port  | Health Check                          |
-| ----------- | ----- | ------------------------------------- |
-| PostgreSQL  | 5432  | `pg_isready -U postgres`              |
-| PowerSync   | 8080  | `curl localhost:8080/probes/liveness` |
-| Phoenix API | 4000  | `curl localhost:4000/api/health`      |
-| MongoDB     | 27017 | (PowerSync internal bucket storage)   |
+Ports are defaults — in worktrees they're offset via `.env` (e.g. slot 1: +100).
+
+| Service     | Default Port | Health Check                          |
+| ----------- | ------------ | ------------------------------------- |
+| PostgreSQL  | 5432         | `pg_isready -U postgres`              |
+| PowerSync   | 8080         | `curl localhost:8080/probes/liveness` |
+| Phoenix API | 4000         | `curl localhost:4000/api/health`      |
+| MongoDB     | 27017        | (PowerSync internal bucket storage)   |
 
 **Restart everything:** `cd nebbler-api && docker compose down && docker compose up -d`
 **View logs:** `docker compose logs -f api powersync`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# CLAUDE.md — Nebbler Mobile App
 
-This file provides guidance for AI agents (Claude, Cursor, Copilot, etc.) working on the Nebbler codebase.
+Guidance for AI agents working on the Nebbler mobile app.
 
 ## Project Overview
 
@@ -21,9 +21,13 @@ npm run format:check   # Prettier check
 npm run typecheck      # TypeScript type checking
 npm run knip           # Detect unused code, exports, and dependencies
 npm run test:coverage  # Jest with coverage report
+./bin/start            # Start Expo (auto-detects worktree ports)
+./bin/health           # Check API + PowerSync health
 ```
 
 **Always run `npm run check` before committing** to catch issues early.
+
+**Worktree:** `bin/start` and `bin/health` auto-detect if running in a worktree by checking `../api/.env`. In the main repo they use default ports. See root `AGENTS.md` for full worktree workflow.
 
 **Coverage:** Per-glob Istanbul thresholds in `jest.config.js` — CI fails if covered directories drop below their minimums.
 
@@ -38,7 +42,7 @@ src/
 ├── context/        # React contexts (AuthContext)
 ├── services/       # API service layer (authService)
 ├── database/       # PowerSync database layer (schema, connector, sync)
-├── constants/      # App constants (config, colors)
+├── constants/      # App constants (config with dynamic port detection, colors)
 ├── types/          # TypeScript type declarations
 └── utils/          # Utility functions
 ```

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,16 @@
+import type { ExpoConfig } from 'expo/config';
+
+import appJson from './app.json';
+
+const apiPort = process.env.API_PORT || '4000';
+const powersyncPort = process.env.POWERSYNC_PORT || '8080';
+
+const config: ExpoConfig = {
+  ...(appJson.expo as ExpoConfig),
+  extra: {
+    apiPort,
+    powersyncPort,
+  },
+};
+
+export default config;

--- a/bin/health
+++ b/bin/health
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check the health of the API and PowerSync services.
+# Auto-detects worktree ports from ../api/.env if present.
+#
+# Usage: ./bin/health
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(dirname "$SCRIPT_DIR")"
+API_ENV="$APP_DIR/../api/.env"
+
+API_PORT=4000
+POWERSYNC_PORT=8080
+
+if [[ -f "$API_ENV" ]]; then
+  API_PORT=$(grep -E '^API_PORT=' "$API_ENV" | cut -d= -f2)
+  POWERSYNC_PORT=$(grep -E '^POWERSYNC_PORT=' "$API_ENV" | cut -d= -f2)
+  SLOT=$(( (API_PORT - 4000) / 100 ))
+  echo "Worktree (slot $SLOT)"
+else
+  echo "Main stack"
+fi
+
+echo ""
+
+printf "API        (:%s)  " "$API_PORT"
+if curl -sf "http://localhost:$API_PORT/api/health" > /dev/null 2>&1; then
+  echo "OK"
+else
+  echo "DOWN"
+fi
+
+printf "PowerSync  (:%s)  " "$POWERSYNC_PORT"
+if curl -sf "http://localhost:$POWERSYNC_PORT/probes/liveness" > /dev/null 2>&1; then
+  echo "OK"
+else
+  echo "DOWN"
+fi

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the Expo dev server, auto-detecting worktree port configuration.
+#
+# In a worktree:  reads ports from ../api/.env, picks an offset Expo port
+# In main repo:   uses default ports (API=4000, PowerSync=8080, Expo=8081)
+#
+# Usage: ./bin/start [expo args...]
+#   ./bin/start              # start normally
+#   ./bin/start --ios        # start and open iOS simulator
+#   ./bin/start --android    # start and open Android emulator
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(dirname "$SCRIPT_DIR")"
+API_ENV="$APP_DIR/../api/.env"
+
+if [[ -f "$API_ENV" ]]; then
+  # Worktree layout: app/ and api/ are siblings
+  API_PORT=$(grep -E '^API_PORT=' "$API_ENV" | cut -d= -f2)
+  POWERSYNC_PORT=$(grep -E '^POWERSYNC_PORT=' "$API_ENV" | cut -d= -f2)
+
+  # Derive Expo port from the slot offset (API 4100 → slot 1 → Expo 8082)
+  SLOT=$(( (API_PORT - 4000) / 100 ))
+  EXPO_PORT=$(( 8081 + SLOT ))
+
+  export API_PORT POWERSYNC_PORT
+
+  echo "Worktree detected (slot $SLOT)"
+  echo "  API:       localhost:$API_PORT"
+  echo "  PowerSync: localhost:$POWERSYNC_PORT"
+  echo "  Expo:      localhost:$EXPO_PORT"
+  echo ""
+
+  exec npx expo start --port "$EXPO_PORT" "$@"
+else
+  exec npx expo start "$@"
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@react-navigation/native-stack": "^7.12.0",
         "@tanstack/react-query": "^5.90.21",
         "expo": "~54.0.33",
+        "expo-constants": "~18.0.13",
         "expo-secure-store": "^15.0.8",
         "expo-status-bar": "~3.0.9",
         "nativewind": "^4.2.1",
@@ -11079,6 +11080,20 @@
         }
       }
     },
+    "node_modules/expo-constants": {
+      "version": "18.0.13",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
+      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/env": "~2.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
@@ -11455,20 +11470,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-constants": {
-      "version": "18.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
-      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8"
-      },
-      "peerDependencies": {
-        "expo": "*",
         "react-native": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@react-navigation/native-stack": "^7.12.0",
     "@tanstack/react-query": "^5.90.21",
     "expo": "~54.0.33",
+    "expo-constants": "~18.0.13",
     "expo-secure-store": "^15.0.8",
     "expo-status-bar": "~3.0.9",
     "nativewind": "^4.2.1",

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,32 +1,16 @@
+import Constants from 'expo-constants';
+
 import { PowerSyncConfigSchema } from '@database/schemas';
 
-/**
- * PowerSync configuration
- *
- * For local development with Docker:
- * - PowerSync service runs on port 8080
- * - Phoenix API runs on port 4000
- *
- * For production, replace with your actual URLs.
- *
- * Validated at startup with Zod — throws if URLs are invalid.
- */
+const apiPort = Constants.expoConfig?.extra?.apiPort ?? '4000';
+const powersyncPort = Constants.expoConfig?.extra?.powersyncPort ?? '8080';
+
 export const powersyncConfig = PowerSyncConfigSchema.parse({
-  /**
-   * PowerSync instance URL
-   * Local: http://localhost:8080
-   * Production: https://<instance-id>.powersync.journeyapps.com
-   */
   powersyncUrl: __DEV__
-    ? 'http://localhost:8080'
+    ? `http://localhost:${powersyncPort}`
     : 'https://YOUR_INSTANCE_ID.powersync.journeyapps.com',
 
-  /**
-   * Backend API URL for authentication and write operations
-   * Local: http://localhost:4000
-   * Production: Your deployed API URL
-   */
-  backendUrl: __DEV__ ? 'http://localhost:4000' : 'https://your-backend-api.com',
+  backendUrl: __DEV__ ? `http://localhost:${apiPort}` : 'https://your-backend-api.com',
 });
 
 /**


### PR DESCRIPTION
## Summary

- Add `app.config.ts` that wraps `app.json` and injects `API_PORT` / `POWERSYNC_PORT` from environment variables into `expo.extra` (defaults to 4000/8080)
- Update `src/constants/config.ts` to read ports from `Constants.expoConfig.extra` via `expo-constants` instead of hardcoding `localhost:4000` and `localhost:8080`
- Install `expo-constants` as an explicit dependency

This allows running multiple Expo dev servers against different API stacks when developing in parallel worktrees (e.g. `API_PORT=4100 POWERSYNC_PORT=8180 npx expo start --port 8082`).

Companion PR in nebbler-api: MDodge0811/nebbler-api#feat/worktree-support

## Test plan

- [ ] `npm run check` passes (lint, format, typecheck, 244 tests)
- [ ] Default behavior unchanged — without env vars, ports fall back to 4000/8080
- [ ] `API_PORT=4100 POWERSYNC_PORT=8180 npx expo start` connects to the offset ports
- [ ] App connects to PowerSync and API successfully on both default and custom ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)