### PR TITLE
feat: event CRUD — calendar picker, detail view, edit & delete

### DIFF
--- a/src/components/CalendarPickerSheet.tsx
+++ b/src/components/CalendarPickerSheet.tsx
@@ -1,0 +1,85 @@
+import { FlatList, Modal, StyleSheet, View } from 'react-native';
+import { tva } from '@gluestack-ui/utils/nativewind-utils';
+import { Box } from '@/components/ui/box';
+import { Text } from '@/components/ui/text';
+import { HStack } from '@/components/ui/hstack';
+import { Pressable } from '@/components/ui/pressable';
+import { getCalendarColor } from '@utils/calendarColor';
+import type { WritableCalendar } from '@hooks/useWritableCalendars';
+
+const overlayStyle = tva({ base: 'flex-1 justify-end' });
+const sheetStyle = tva({
+  base: 'rounded-t-2xl bg-background-0 pb-8 pt-4',
+});
+const titleStyle = tva({ base: 'mb-2 px-4 text-lg font-semibold text-typography-900' });
+const rowStyle = tva({ base: 'items-center px-4 py-3' });
+const calendarNameStyle = tva({ base: 'flex-1 text-base text-typography-900' });
+const badgeStyle = tva({ base: 'text-xs text-typography-400' });
+const emptyStyle = tva({ base: 'px-4 py-8 text-center text-base text-typography-400' });
+
+const styles = StyleSheet.create({
+  overlay: { backgroundColor: 'rgba(0,0,0,0.4)' },
+  dot: { width: 12, height: 12, borderRadius: 6, marginRight: 12 },
+  checkmark: { fontSize: 16, color: '#00DB74', marginLeft: 8 },
+});
+
+function getTypeBadge(type: string | null): string {
+  switch (type) {
+    case 'private':
+      return 'Private';
+    case 'shared':
+      return 'Shared';
+    case 'public':
+      return 'Group';
+    default:
+      return '';
+  }
+}
+
+interface CalendarPickerSheetProps {
+  visible: boolean;
+  calendars: WritableCalendar[];
+  selectedCalendarId: string | null;
+  onSelect: (calendar: WritableCalendar) => void;
+  onClose: () => void;
+}
+
+export function CalendarPickerSheet({
+  visible,
+  calendars,
+  selectedCalendarId,
+  onSelect,
+  onClose,
+}: CalendarPickerSheetProps) {
+  const renderItem = ({ item }: { item: WritableCalendar }) => {
+    const isSelected = item.id === selectedCalendarId;
+    const color = getCalendarColor(item.id);
+    const badge = getTypeBadge(item.type);
+
+    return (
+      <Pressable onPress={() => onSelect(item)}>
+        <HStack className={rowStyle({})}>
+          <View style={[styles.dot, { backgroundColor: color }]} />
+          <Text className={calendarNameStyle({})}>{item.name}</Text>
+          {badge ? <Text className={badgeStyle({})}>{badge}</Text> : null}
+          {isSelected ? <Text style={styles.checkmark}>&#x2713;</Text> : null}
+        </HStack>
+      </Pressable>
+    );
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable className={overlayStyle({})} style={styles.overlay} onPress={onClose}>
+        <Box className={sheetStyle({})}>
+          <Text className={titleStyle({})}>Select Calendar</Text>
+          {calendars.length === 0 ? (
+            <Text className={emptyStyle({})}>No calendars available</Text>
+          ) : (
+            <FlatList data={calendars} renderItem={renderItem} keyExtractor={(item) => item.id} />
+          )}
+        </Box>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/src/hooks/useCalendarEvents.ts
+++ b/src/hooks/useCalendarEvents.ts
@@ -130,6 +130,10 @@ export function useEventMutations() {
       setClauses.push('end_time = ?');
       values.push(updates.end_time);
     }
+    if (updates.calendar_id !== undefined) {
+      setClauses.push('calendar_id = ?');
+      values.push(updates.calendar_id);
+    }
 
     if (setClauses.length === 0) return;
 

--- a/src/hooks/useEventDetail.ts
+++ b/src/hooks/useEventDetail.ts
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+import { useQuery } from '@powersync/react';
+import { useCurrentUser } from '@hooks/useCurrentUser';
+import type { Event, Calendar, User } from '@database/schema';
+
+interface MembershipRow {
+  id: string;
+  calendar_id: string;
+  user_id: string;
+  role_id: string;
+  view_mode: string | null;
+  can_delete_events: number;
+  role_level: number;
+  role_name: string;
+}
+
+export interface EventPermissions {
+  canEdit: boolean;
+  canDelete: boolean;
+  isFreeBusy: boolean;
+}
+
+/**
+ * Composite hook for the Event Detail screen.
+ * Returns the event, its calendar, creator, current user's membership, and computed permissions.
+ */
+export function useEventDetail(eventId: string | undefined) {
+  const { authUser } = useCurrentUser();
+  const userId = authUser?.id;
+
+  // 1. Event by ID
+  const { data: events = [] } = useQuery<Event>(
+    eventId
+      ? 'SELECT * FROM events WHERE id = ? AND deleted_at IS NULL'
+      : 'SELECT * FROM events WHERE 0',
+    eventId ? [eventId] : []
+  );
+  const event = events[0] ?? null;
+
+  // 2. Calendar by event.calendar_id
+  const calendarId = event?.calendar_id;
+  const { data: calendars = [] } = useQuery<Calendar>(
+    calendarId ? 'SELECT * FROM calendars WHERE id = ?' : 'SELECT * FROM calendars WHERE 0',
+    calendarId ? [calendarId] : []
+  );
+  const calendar = calendars[0] ?? null;
+
+  // 3. Creator user
+  const creatorId = event?.created_by_user_id;
+  const { data: creators = [] } = useQuery<User>(
+    creatorId ? 'SELECT * FROM users WHERE id = ?' : 'SELECT * FROM users WHERE 0',
+    creatorId ? [creatorId] : []
+  );
+  const creator = creators[0] ?? null;
+
+  // 4. Current user's membership + role level for this calendar
+  const { data: memberships = [] } = useQuery<MembershipRow>(
+    calendarId && userId
+      ? `SELECT cm.*, r.level AS role_level, r.name AS role_name
+         FROM calendar_members cm
+         JOIN roles r ON cm.role_id = r.id
+         WHERE cm.calendar_id = ? AND cm.user_id = ? AND cm.deleted_at IS NULL`
+      : 'SELECT * FROM calendar_members WHERE 0',
+    calendarId && userId ? [calendarId, userId] : []
+  );
+  const membership = memberships[0] ?? null;
+
+  // 5. Computed permissions
+  const permissions = useMemo<EventPermissions>(() => {
+    if (!event || !userId) {
+      return { canEdit: false, canDelete: false, isFreeBusy: false };
+    }
+
+    const isCreator = event.created_by_user_id === userId;
+    const roleLevel = membership?.role_level ?? 0;
+
+    const canEdit = isCreator || roleLevel >= 20;
+    const canDelete =
+      isCreator || (roleLevel >= 20 && membership?.can_delete_events === 1) || roleLevel >= 30;
+    const isFreeBusy = membership?.view_mode === 'free_busy';
+
+    return { canEdit, canDelete, isFreeBusy };
+  }, [event, userId, membership]);
+
+  return { event, calendar, creator, membership, permissions };
+}

--- a/src/hooks/useWritableCalendars.ts
+++ b/src/hooks/useWritableCalendars.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@powersync/react';
+import type { Calendar } from '@database/schema';
+
+export interface WritableCalendar extends Calendar {
+  role_level: number;
+}
+
+/**
+ * Reactive query for calendars where the user has role level >= 20 (manager+).
+ * Returns calendars the user can create/edit events in.
+ */
+export function useWritableCalendars(userId: string | undefined) {
+  return useQuery<WritableCalendar>(
+    userId
+      ? `SELECT c.*, r.level AS role_level
+         FROM calendars c
+         JOIN calendar_members cm ON c.id = cm.calendar_id
+         JOIN roles r ON cm.role_id = r.id
+         WHERE cm.user_id = ?
+           AND cm.deleted_at IS NULL
+           AND c.deleted_at IS NULL
+           AND r.level >= 20
+         ORDER BY c.name ASC`
+      : 'SELECT * FROM calendars WHERE 0',
+    userId ? [userId] : []
+  );
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -14,6 +14,7 @@ import { PeopleScreen } from '@screens/PeopleScreen';
 import { SettingsScreen } from '@screens/SettingsScreen';
 import { ProfileScreen } from '@screens/ProfileScreen';
 import { CreateEventScreen } from '@screens/CreateEventScreen';
+import { EventDetailScreen } from '@screens/EventDetailScreen';
 import { DrawerContent } from '@components/schedule/DrawerContent';
 import { CustomTabBar } from '@components/schedule/CustomTabBar';
 import { AuthNavigator } from './AuthNavigator';
@@ -85,6 +86,7 @@ function MainNavigator() {
       <Stack.Screen name="Main" component={MainDrawer} options={{ headerShown: false }} />
       <Stack.Screen name="Profile" component={ProfileScreen} />
       <Stack.Screen name="CreateEvent" component={CreateEventScreen} />
+      <Stack.Screen name="EventDetail" component={EventDetailScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -16,6 +16,7 @@ export type RootStackParamList = {
   Main: NavigatorScreenParams<DrawerParamList>;
   Profile: undefined;
   CreateEvent: undefined;
+  EventDetail: { eventId: string };
 };
 
 export type MainTabParamList = {

--- a/src/screens/CreateEventScreen.tsx
+++ b/src/screens/CreateEventScreen.tsx
@@ -17,11 +17,13 @@ import { Text } from '@/components/ui/text';
 import { HStack } from '@/components/ui/hstack';
 import { VStack } from '@/components/ui/vstack';
 import { Pressable } from '@/components/ui/pressable';
-import { useCalendars } from '@hooks/useCalendars';
 import { useCurrentUser } from '@hooks/useCurrentUser';
 import { useEventMutations } from '@hooks/useCalendarEvents';
+import { useWritableCalendars, type WritableCalendar } from '@hooks/useWritableCalendars';
+import { CalendarPickerSheet } from '@components/CalendarPickerSheet';
 import { CreateEventSchema } from '@database/schemas';
 import { formatDateShort, formatTime } from '@utils/formatTime';
+import { getCalendarColor } from '@utils/calendarColor';
 import { ZodError } from 'zod';
 
 // --- Styles ---
@@ -78,8 +80,8 @@ type PickerTarget = 'startDate' | 'startTime' | 'endDate' | 'endTime' | null;
 
 export function CreateEventScreen() {
   const navigation = useNavigation();
-  const { data: calendars } = useCalendars();
   const { authUser } = useCurrentUser();
+  const { data: writableCalendars = [] } = useWritableCalendars(authUser?.id);
   const { createEvent } = useEventMutations();
 
   const defaultStart = useMemo(() => getNextWholeHour(), []);
@@ -94,10 +96,25 @@ export function CreateEventScreen() {
   const [pickerTarget, setPickerTarget] = useState<PickerTarget>(null);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
   const [isSaving, setIsSaving] = useState(false);
+  const [selectedCalendarId, setSelectedCalendarId] = useState<string | null>(null);
+  const [showCalendarPicker, setShowCalendarPicker] = useState(false);
 
   const titleInputRef = useRef<TextInput>(null);
 
-  const calendar = calendars?.[0];
+  // Default to first writable calendar when available
+  const calendar =
+    writableCalendars.find((c) => c.id === selectedCalendarId) ?? writableCalendars[0];
+
+  useEffect(() => {
+    if (!selectedCalendarId && writableCalendars.length > 0) {
+      setSelectedCalendarId(writableCalendars[0].id);
+    }
+  }, [selectedCalendarId, writableCalendars]);
+
+  const handleCalendarSelect = useCallback((cal: WritableCalendar) => {
+    setSelectedCalendarId(cal.id);
+    setShowCalendarPicker(false);
+  }, []);
 
   // Derived state
   const isDirty =
@@ -277,9 +294,17 @@ export function CreateEventScreen() {
           <View className={dividerStyle({})} />
 
           {/* Calendar row */}
-          <Pressable className="py-4" onPress={() => {}}>
+          <Pressable className="py-4" onPress={() => setShowCalendarPicker(true)}>
             <HStack className="items-center">
-              <View style={[styles.calendarDot, { backgroundColor: '#00DB74', marginRight: 10 }]} />
+              <View
+                style={[
+                  styles.calendarDot,
+                  {
+                    backgroundColor: calendar ? getCalendarColor(calendar.id) : '#00DB74',
+                    marginRight: 10,
+                  },
+                ]}
+              />
               <Text className={calendarNameStyle({})}>{calendar?.name ?? 'Personal Calendar'}</Text>
               <Text className={chevronStyle({})}>&#x203A;</Text>
             </HStack>
@@ -373,6 +398,14 @@ export function CreateEventScreen() {
           )}
         </VStack>
       </ScrollView>
+
+      <CalendarPickerSheet
+        visible={showCalendarPicker}
+        calendars={writableCalendars}
+        selectedCalendarId={selectedCalendarId}
+        onSelect={handleCalendarSelect}
+        onClose={() => setShowCalendarPicker(false)}
+      />
     </KeyboardAvoidingView>
   );
 }

--- a/src/screens/EventDetailScreen.tsx
+++ b/src/screens/EventDetailScreen.tsx
@@ -1,0 +1,614 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable as RNPressable,
+  ScrollView,
+  StyleSheet,
+  Text as RNText,
+  TextInput,
+  View,
+} from 'react-native';
+import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { tva } from '@gluestack-ui/utils/nativewind-utils';
+import { Box } from '@/components/ui/box';
+import { Text } from '@/components/ui/text';
+import { HStack } from '@/components/ui/hstack';
+import { VStack } from '@/components/ui/vstack';
+import { Pressable } from '@/components/ui/pressable';
+import { useEventDetail } from '@hooks/useEventDetail';
+import { useEventMutations } from '@hooks/useCalendarEvents';
+import { useWritableCalendars, type WritableCalendar } from '@hooks/useWritableCalendars';
+import { useCurrentUser } from '@hooks/useCurrentUser';
+import { CalendarPickerSheet } from '@components/CalendarPickerSheet';
+import { CreateEventSchema } from '@database/schemas';
+import { getCalendarColor } from '@utils/calendarColor';
+import { formatEventDateTime, formatDateShort, formatTime } from '@utils/formatTime';
+import type { RootStackParamList } from '@navigation/types';
+import { ZodError } from 'zod';
+
+// --- Styles ---
+
+const containerStyle = tva({ base: 'flex-1 bg-background-0' });
+const sectionLabelStyle = tva({ base: 'text-sm text-typography-500' });
+const valueStyle = tva({ base: 'mt-1 text-base text-typography-900' });
+const dateTimeTextStyle = tva({ base: 'text-base text-typography-900' });
+const dateTimeSeparatorStyle = tva({ base: 'text-base text-typography-400' });
+const dividerStyle = tva({ base: 'h-px bg-outline-200' });
+const calendarNameStyle = tva({ base: 'flex-1 text-base text-typography-900' });
+const chevronStyle = tva({ base: 'text-base text-typography-400' });
+const errorTextStyle = tva({ base: 'mt-1 text-sm text-error-600' });
+
+const styles = StyleSheet.create({
+  scrollContent: { flexGrow: 1 },
+  calendarDot: { width: 10, height: 10, borderRadius: 5 },
+  busyBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 12,
+    backgroundColor: '#F3F4F6',
+  },
+  titleInput: {
+    fontSize: 16,
+    color: '#262627',
+    paddingVertical: 8,
+    paddingHorizontal: 0,
+  },
+  descriptionInput: {
+    fontSize: 16,
+    color: '#262627',
+    minHeight: 100,
+    textAlignVertical: 'top',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    borderColor: '#E5E5E5',
+    borderRadius: 8,
+  },
+  deleteButton: {
+    marginHorizontal: 16,
+    marginTop: 24,
+    marginBottom: 16,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: '#FEE2E2',
+    alignItems: 'center' as const,
+  },
+  deleteButtonText: {
+    fontSize: 16,
+    fontWeight: '600' as const,
+    color: '#DC2626',
+  },
+});
+
+type PickerTarget = 'startDate' | 'startTime' | 'endDate' | 'endTime' | null;
+
+// --- Component ---
+
+export function EventDetailScreen() {
+  const navigation = useNavigation();
+  const route = useRoute<RouteProp<RootStackParamList, 'EventDetail'>>();
+  const { eventId } = route.params;
+
+  const { event, calendar, creator, permissions } = useEventDetail(eventId);
+  const { updateEvent, deleteEvent } = useEventMutations();
+  const { authUser } = useCurrentUser();
+  const { data: writableCalendars = [] } = useWritableCalendars(authUser?.id);
+
+  // --- Edit mode state ---
+  const [isEditing, setIsEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editStartTime, setEditStartTime] = useState(new Date());
+  const [editEndTime, setEditEndTime] = useState(new Date());
+  const [editCalendarId, setEditCalendarId] = useState<string | null>(null);
+  const [pickerTarget, setPickerTarget] = useState<PickerTarget>(null);
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [showCalendarPicker, setShowCalendarPicker] = useState(false);
+
+  // Navigate back if event becomes null (deleted by another client)
+  useEffect(() => {
+    if (event === null && !isEditing) {
+      // Small delay to avoid navigation during render
+      const timer = setTimeout(() => {
+        Alert.alert('Event Deleted', 'This event has been deleted.');
+        navigation.goBack();
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [event, isEditing, navigation]);
+
+  // --- Edit mode helpers ---
+
+  const enterEditMode = useCallback(() => {
+    if (!event) return;
+    setEditTitle(event.title ?? '');
+    setEditDescription(event.description ?? '');
+    setEditStartTime(new Date(event.start_time ?? new Date()));
+    setEditEndTime(new Date(event.end_time ?? new Date()));
+    setEditCalendarId(event.calendar_id);
+    setFormErrors({});
+    setPickerTarget(null);
+    setIsEditing(true);
+  }, [event]);
+
+  const isDirty =
+    isEditing && event
+      ? editTitle !== (event.title ?? '') ||
+        editDescription !== (event.description ?? '') ||
+        editStartTime.toISOString() !== new Date(event.start_time ?? '').toISOString() ||
+        editEndTime.toISOString() !== new Date(event.end_time ?? '').toISOString() ||
+        editCalendarId !== event.calendar_id
+      : false;
+
+  const isValid = isEditing && editTitle.trim().length > 0 && editEndTime > editStartTime;
+
+  const handleCancelEdit = useCallback(() => {
+    if (isDirty) {
+      Alert.alert('Discard Changes?', 'You have unsaved changes that will be lost.', [
+        { text: 'Keep Editing', style: 'cancel' },
+        {
+          text: 'Discard',
+          style: 'destructive',
+          onPress: () => {
+            setIsEditing(false);
+            setFormErrors({});
+            setPickerTarget(null);
+          },
+        },
+      ]);
+    } else {
+      setIsEditing(false);
+      setFormErrors({});
+      setPickerTarget(null);
+    }
+  }, [isDirty]);
+
+  const handleSaveEdit = useCallback(async () => {
+    if (!event || isSaving) return;
+
+    try {
+      CreateEventSchema.parse({
+        title: editTitle,
+        calendarId: editCalendarId,
+        startTime: editStartTime,
+        endTime: editEndTime,
+        description: editDescription || undefined,
+      });
+      setFormErrors({});
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const errors: Record<string, string> = {};
+        err.issues.forEach((issue) => {
+          const field = String(issue.path[0]);
+          if (!errors[field]) errors[field] = issue.message;
+        });
+        setFormErrors(errors);
+      }
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await updateEvent(event.id, {
+        title: editTitle.trim(),
+        description: editDescription.trim() || null,
+        start_time: editStartTime.toISOString(),
+        end_time: editEndTime.toISOString(),
+        calendar_id: editCalendarId,
+      });
+      setIsEditing(false);
+      setFormErrors({});
+      setPickerTarget(null);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    event,
+    isSaving,
+    editTitle,
+    editDescription,
+    editStartTime,
+    editEndTime,
+    editCalendarId,
+    updateEvent,
+  ]);
+
+  const handleDelete = useCallback(() => {
+    if (!event) {
+      Alert.alert('Already Deleted', 'This event was already deleted.');
+      navigation.goBack();
+      return;
+    }
+
+    Alert.alert(`Delete "${event.title}"?`, "This can't be undone.", [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          await deleteEvent(event.id);
+          navigation.goBack();
+        },
+      },
+    ]);
+  }, [event, deleteEvent, navigation]);
+
+  // --- Date/time picker handlers (edit mode) ---
+
+  const handleStartChange = useCallback(
+    (_event: DateTimePickerEvent, date?: Date) => {
+      if (Platform.OS === 'android') setPickerTarget(null);
+      if (!date) return;
+
+      if (pickerTarget === 'startDate') {
+        const next = new Date(editStartTime);
+        next.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
+        setEditStartTime(next);
+        if (editEndTime <= next) setEditEndTime(new Date(next.getTime() + 60 * 60 * 1000));
+      } else {
+        const next = new Date(editStartTime);
+        next.setHours(date.getHours(), date.getMinutes(), 0, 0);
+        setEditStartTime(next);
+        if (editEndTime <= next) setEditEndTime(new Date(next.getTime() + 60 * 60 * 1000));
+      }
+
+      setFormErrors((prev) => {
+        if (!prev.endTime) return prev;
+        const next = { ...prev };
+        delete next.endTime;
+        return next;
+      });
+    },
+    [pickerTarget, editStartTime, editEndTime]
+  );
+
+  const handleEndChange = useCallback(
+    (_event: DateTimePickerEvent, date?: Date) => {
+      if (Platform.OS === 'android') setPickerTarget(null);
+      if (!date) return;
+
+      if (pickerTarget === 'endDate') {
+        const next = new Date(editEndTime);
+        next.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
+        setEditEndTime(next);
+      } else {
+        const next = new Date(editEndTime);
+        next.setHours(date.getHours(), date.getMinutes(), 0, 0);
+        setEditEndTime(next);
+      }
+
+      setFormErrors((prev) => {
+        if (!prev.endTime) return prev;
+        const next = { ...prev };
+        delete next.endTime;
+        return next;
+      });
+    },
+    [pickerTarget, editEndTime]
+  );
+
+  const handleCalendarSelect = useCallback((cal: WritableCalendar) => {
+    setEditCalendarId(cal.id);
+    setShowCalendarPicker(false);
+  }, []);
+
+  const endTimeError =
+    formErrors.endTime ||
+    (isEditing && editEndTime <= editStartTime ? 'End time must be after start time' : undefined);
+  const showEndError = !!formErrors.endTime;
+
+  // --- Header configuration ---
+
+  useEffect(() => {
+    if (isEditing) {
+      navigation.setOptions({
+        title: 'Edit Event',
+        headerLeft: () => (
+          <RNPressable onPress={handleCancelEdit} hitSlop={8}>
+            <RNText style={{ fontSize: 16, color: '#666666' }}>Cancel</RNText>
+          </RNPressable>
+        ),
+        headerRight: () => (
+          <RNPressable onPress={handleSaveEdit} disabled={!isValid || isSaving} hitSlop={8}>
+            <RNText
+              style={{
+                fontSize: 16,
+                fontWeight: '600',
+                color: isValid ? '#00DB74' : '#D4D4D4',
+              }}
+            >
+              Save
+            </RNText>
+          </RNPressable>
+        ),
+      });
+    } else {
+      navigation.setOptions({
+        title: 'Event Details',
+        headerLeft: () => (
+          <RNPressable onPress={() => navigation.goBack()} hitSlop={8}>
+            <RNText style={{ fontSize: 16, color: '#666666' }}>{'\u2039'} Back</RNText>
+          </RNPressable>
+        ),
+        headerRight: () =>
+          permissions.canEdit && !permissions.isFreeBusy ? (
+            <RNPressable onPress={enterEditMode} hitSlop={8}>
+              <RNText style={{ fontSize: 16, fontWeight: '600', color: '#00DB74' }}>Edit</RNText>
+            </RNPressable>
+          ) : null,
+      });
+    }
+  }, [
+    navigation,
+    isEditing,
+    isValid,
+    isSaving,
+    permissions.canEdit,
+    permissions.isFreeBusy,
+    handleCancelEdit,
+    handleSaveEdit,
+    enterEditMode,
+  ]);
+
+  // --- Render ---
+
+  if (!event) {
+    return (
+      <Box className="flex-1 items-center justify-center bg-background-0">
+        <Text className="text-base text-typography-400">Loading...</Text>
+      </Box>
+    );
+  }
+
+  const calendarColor = calendar ? getCalendarColor(calendar.id) : '#00DB74';
+
+  // Free/busy mode — show minimal info
+  if (permissions.isFreeBusy) {
+    return (
+      <Box className={containerStyle({})}>
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          <VStack className="px-4 pt-4">
+            {/* Calendar dot */}
+            <HStack className="items-center py-4">
+              <View
+                style={[styles.calendarDot, { backgroundColor: calendarColor, marginRight: 10 }]}
+              />
+              <Text className={calendarNameStyle({})}>{calendar?.name ?? 'Calendar'}</Text>
+            </HStack>
+            <View className={dividerStyle({})} />
+
+            {/* Time */}
+            <VStack className="py-4">
+              <Text className={sectionLabelStyle({})}>Time</Text>
+              <Text className={valueStyle({})}>
+                {event.start_time && event.end_time
+                  ? formatEventDateTime(event.start_time, event.end_time)
+                  : ''}
+              </Text>
+            </VStack>
+            <View className={dividerStyle({})} />
+
+            {/* Busy badge */}
+            <VStack className="items-start py-4">
+              <View style={styles.busyBadge}>
+                <Text className="text-sm text-typography-600">Busy</Text>
+              </View>
+            </VStack>
+          </VStack>
+        </ScrollView>
+      </Box>
+    );
+  }
+
+  // --- Edit mode ---
+  if (isEditing) {
+    const editCalendar = writableCalendars.find((c) => c.id === editCalendarId);
+
+    return (
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className={containerStyle({})}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <VStack className="px-4 pt-4">
+            {/* Title */}
+            <TextInput
+              style={styles.titleInput}
+              placeholder="Event title"
+              placeholderTextColor="#A3A3A3"
+              value={editTitle}
+              onChangeText={setEditTitle}
+              autoFocus
+              returnKeyType="done"
+            />
+            <View className={dividerStyle({})} />
+
+            {/* Calendar row */}
+            <Pressable className="py-4" onPress={() => setShowCalendarPicker(true)}>
+              <HStack className="items-center">
+                <View
+                  style={[
+                    styles.calendarDot,
+                    {
+                      backgroundColor: editCalendar
+                        ? getCalendarColor(editCalendar.id)
+                        : calendarColor,
+                      marginRight: 10,
+                    },
+                  ]}
+                />
+                <Text className={calendarNameStyle({})}>
+                  {editCalendar?.name ?? calendar?.name ?? 'Calendar'}
+                </Text>
+                <Text className={chevronStyle({})}>&#x203A;</Text>
+              </HStack>
+            </Pressable>
+            <View className={dividerStyle({})} />
+
+            {/* Start date/time */}
+            <VStack className="py-4">
+              <Text className={sectionLabelStyle({})}>Starts</Text>
+              <HStack className="mt-1 items-center">
+                <Pressable onPress={() => setPickerTarget('startDate')}>
+                  <Text className={dateTimeTextStyle({})}>{formatDateShort(editStartTime)}</Text>
+                </Pressable>
+                <Text className={dateTimeSeparatorStyle({})}> &middot; </Text>
+                <Pressable onPress={() => setPickerTarget('startTime')}>
+                  <Text className={dateTimeTextStyle({})}>{formatTime(editStartTime)}</Text>
+                </Pressable>
+              </HStack>
+            </VStack>
+
+            {(pickerTarget === 'startDate' || pickerTarget === 'startTime') && (
+              <DateTimePicker
+                value={editStartTime}
+                mode={pickerTarget === 'startDate' ? 'date' : 'time'}
+                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                onChange={handleStartChange}
+                minuteInterval={5}
+              />
+            )}
+
+            <View className={dividerStyle({})} />
+
+            {/* End date/time */}
+            <VStack className="py-4">
+              <Text className={sectionLabelStyle({})}>Ends</Text>
+              <HStack className="mt-1 items-center">
+                <Pressable onPress={() => setPickerTarget('endDate')}>
+                  <Text
+                    className={dateTimeTextStyle({})}
+                    style={showEndError ? { color: '#DC2626' } : undefined}
+                  >
+                    {formatDateShort(editEndTime)}
+                  </Text>
+                </Pressable>
+                <Text className={dateTimeSeparatorStyle({})}> &middot; </Text>
+                <Pressable onPress={() => setPickerTarget('endTime')}>
+                  <Text
+                    className={dateTimeTextStyle({})}
+                    style={showEndError ? { color: '#DC2626' } : undefined}
+                  >
+                    {formatTime(editEndTime)}
+                  </Text>
+                </Pressable>
+              </HStack>
+              {showEndError && endTimeError && (
+                <Text className={errorTextStyle({})}>{endTimeError}</Text>
+              )}
+            </VStack>
+
+            {(pickerTarget === 'endDate' || pickerTarget === 'endTime') && (
+              <DateTimePicker
+                value={editEndTime}
+                mode={pickerTarget === 'endDate' ? 'date' : 'time'}
+                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                onChange={handleEndChange}
+                minuteInterval={5}
+              />
+            )}
+
+            <View className={dividerStyle({})} />
+
+            {/* Description */}
+            <VStack className="py-4">
+              <Text className={sectionLabelStyle({})}>Description</Text>
+              <TextInput
+                style={styles.descriptionInput}
+                placeholder="Add a description"
+                placeholderTextColor="#A3A3A3"
+                value={editDescription}
+                onChangeText={setEditDescription}
+                multiline
+                numberOfLines={4}
+              />
+            </VStack>
+          </VStack>
+        </ScrollView>
+
+        <CalendarPickerSheet
+          visible={showCalendarPicker}
+          calendars={writableCalendars}
+          selectedCalendarId={editCalendarId}
+          onSelect={handleCalendarSelect}
+          onClose={() => setShowCalendarPicker(false)}
+        />
+      </KeyboardAvoidingView>
+    );
+  }
+
+  // --- View mode ---
+  return (
+    <Box className={containerStyle({})}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <VStack className="px-4 pt-4">
+          {/* Title */}
+          <VStack className="py-4">
+            <Text className="text-xl font-bold text-typography-900">{event.title}</Text>
+          </VStack>
+          <View className={dividerStyle({})} />
+
+          {/* Calendar */}
+          <HStack className="items-center py-4">
+            <View
+              style={[styles.calendarDot, { backgroundColor: calendarColor, marginRight: 10 }]}
+            />
+            <Text className={calendarNameStyle({})}>{calendar?.name ?? 'Calendar'}</Text>
+          </HStack>
+          <View className={dividerStyle({})} />
+
+          {/* Creator */}
+          {creator && (
+            <>
+              <VStack className="py-4">
+                <Text className={sectionLabelStyle({})}>Created by</Text>
+                <Text className={valueStyle({})}>
+                  {creator.display_name ||
+                    `${creator.first_name ?? ''} ${creator.last_name ?? ''}`.trim() ||
+                    creator.email}
+                </Text>
+              </VStack>
+              <View className={dividerStyle({})} />
+            </>
+          )}
+
+          {/* Date/time */}
+          <VStack className="py-4">
+            <Text className={sectionLabelStyle({})}>Date & Time</Text>
+            <Text className={valueStyle({})}>
+              {event.start_time && event.end_time
+                ? formatEventDateTime(event.start_time, event.end_time)
+                : ''}
+            </Text>
+          </VStack>
+          <View className={dividerStyle({})} />
+
+          {/* Description */}
+          {event.description ? (
+            <>
+              <VStack className="py-4">
+                <Text className={sectionLabelStyle({})}>Description</Text>
+                <Text className={valueStyle({})}>{event.description}</Text>
+              </VStack>
+              <View className={dividerStyle({})} />
+            </>
+          ) : null}
+        </VStack>
+
+        {/* Delete button */}
+        {permissions.canDelete && (
+          <RNPressable style={styles.deleteButton} onPress={handleDelete}>
+            <RNText style={styles.deleteButtonText}>Delete Event</RNText>
+          </RNPressable>
+        )}
+      </ScrollView>
+    </Box>
+  );
+}

--- a/src/screens/ScheduleScreen.tsx
+++ b/src/screens/ScheduleScreen.tsx
@@ -12,6 +12,7 @@ import { useScheduleFeed } from '@hooks/useScheduleFeed';
 import { useCalendarEvents, useMarkedDates } from '@hooks/useCalendarEvents';
 import { useScheduleStore } from '@stores/useScheduleStore';
 import { getMonthBufferRange, monthKeyOf } from '@utils/dateRange';
+import type { FeedEvent } from '@hooks/useScheduleFeed';
 
 const containerStyle = tva({ base: 'flex-1 bg-background-0' });
 const errorBannerStyle = tva({ base: 'bg-error-50 px-4 py-2' });
@@ -79,6 +80,13 @@ export function ScheduleScreen() {
   const handleNavigateToProfile = useCallback(() => {
     navigation.navigate('Profile');
   }, [navigation]);
+
+  const handleEventPress = useCallback(
+    (event: FeedEvent) => {
+      navigation.navigate('EventDetail', { eventId: event.id });
+    },
+    [navigation]
+  );
 
   const handleRefresh = useCallback(() => {
     setRefreshing(true);
@@ -160,6 +168,7 @@ export function ScheduleScreen() {
           sections={sections}
           refreshing={refreshing}
           onRefresh={handleRefresh}
+          onEventPress={handleEventPress}
           onViewableItemsChanged={handleViewableItemsChanged}
         />
       )}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -4,5 +4,6 @@ export { CalendarsScreen } from './CalendarsScreen';
 export { PeopleScreen } from './PeopleScreen';
 export { ProfileScreen } from './ProfileScreen';
 export { CreateEventScreen } from './CreateEventScreen';
+export { EventDetailScreen } from './EventDetailScreen';
 export { LoginScreen } from './auth/LoginScreen';
 export { RegisterScreen } from './auth/RegisterScreen';

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -34,6 +34,20 @@ export function formatTimeShort(isoString: string): string {
 const shortWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const fullMonths = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
 
 /**
  * Formats a Date object into a short date string.
@@ -49,6 +63,43 @@ export function formatDateShort(date: Date): string {
  */
 export function formatTime(date: Date): string {
   return formatLocalTime(date);
+}
+
+/**
+ * Formats a start/end ISO timestamp pair into a long-form event date/time string.
+ * e.g. "Tuesday, March 3 · 2:00 – 3:30 PM"
+ *
+ * If start and end are on different dates:
+ * "Tuesday, March 3, 2:00 PM – Wednesday, March 4, 3:30 PM"
+ */
+export function formatEventDateTime(startTime: string, endTime: string): string {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+
+  const startDay = `${weekdays[start.getDay()]}, ${fullMonths[start.getMonth()]} ${start.getDate()}`;
+  const endDay = `${weekdays[end.getDay()]}, ${fullMonths[end.getMonth()]} ${end.getDate()}`;
+
+  const startTimeStr = formatLocalTime(start);
+  const endTimeStr = formatLocalTime(end);
+
+  if (
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate()
+  ) {
+    // Same day — collapse AM/PM if both share the same period
+    const startPeriod = start.getHours() >= 12 ? 'PM' : 'AM';
+    const endPeriod = end.getHours() >= 12 ? 'PM' : 'AM';
+
+    if (startPeriod === endPeriod) {
+      const startNoSuffix = startTimeStr.replace(/ [AP]M$/, '');
+      return `${startDay} \u00B7 ${startNoSuffix} \u2013 ${endTimeStr}`;
+    }
+
+    return `${startDay} \u00B7 ${startTimeStr} \u2013 ${endTimeStr}`;
+  }
+
+  return `${startDay}, ${startTimeStr} \u2013 ${endDay}, ${endTimeStr}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements the remaining 4 sub-issues of NEB-58 (CreateEventScreen):

- **NEB-82 — Calendar Picker**: Bottom sheet modal for selecting writable calendars (role level ≥ 20). Replaces hardcoded first-calendar selection on CreateEventScreen with `useWritableCalendars` hook + `CalendarPickerSheet` component.
- **NEB-80 — Event Detail / View Page**: Read-only `EventDetailScreen` showing title, calendar, creator, date/time, and description. Includes free/busy mode (minimal view for restricted members). Wired from `ScheduleScreen` via `onEventPress`.
- **NEB-81 — Edit Event Flow**: Inline edit mode on EventDetailScreen with dirty checking, discard confirmation, Zod validation, and calendar reassignment support.
- **NEB-99 — Delete Event Flow**: Permission-gated delete button with confirmation alert. Handles edge case where event is already deleted by another client.

### Files changed

| File | Change |
|------|--------|
| `src/hooks/useWritableCalendars.ts` | **New** — queries calendars where user has manager+ role |
| `src/components/CalendarPickerSheet.tsx` | **New** — modal bottom sheet calendar picker |
| `src/hooks/useEventDetail.ts` | **New** — composite hook (event, calendar, creator, membership, permissions) |
| `src/screens/EventDetailScreen.tsx` | **New** — view/edit/delete screen with permission gating |
| `src/utils/formatTime.ts` | Added `formatEventDateTime` for long-form date display |
| `src/hooks/useCalendarEvents.ts` | Added `calendar_id` to `updateEvent` |
| `src/navigation/types.ts` | Added `EventDetail` route |
| `src/navigation/AppNavigator.tsx` | Registered `EventDetailScreen` |
| `src/screens/index.ts` | Exported `EventDetailScreen` |
| `src/screens/CreateEventScreen.tsx` | Integrated calendar picker |
| `src/screens/ScheduleScreen.tsx` | Wired `onEventPress` to navigate to EventDetail |

## Test plan

- [x] Tap calendar row on Create Event → picker opens, shows writable calendars with color dots and type badges, selection persists and updates color
- [x] Tap event on ScheduleScreen → EventDetailScreen opens with correct title, calendar, creator, date/time, description
- [x] Back button returns to schedule
- [x] Free/busy members see only time + "Busy" label, no title/description/edit/delete
- [x] Tap Edit → fields become editable, pre-populated from event data
- [x] Modify fields → Save validates and updates event, view mode reflects changes
- [x] Cancel with unsaved changes → discard confirmation alert
- [x] Delete button visible only for users with delete permission
- [x] Tap Delete → confirmation alert → event removed → navigate back
- [x] If event deleted by another client while viewing → alert + navigate back
- [x] `npm run check` passes (lint, format, typecheck, 244 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)